### PR TITLE
Fix crash in identifyMajorPeaks() for flat/constant input signals

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# MassSpecWavelet development version
+
+- `identifyMajorPeaks()`: Fix `Error in strsplit(ridgeName, "_") : non-character
+  argument` crash when no ridges are found (e.g. for a flat/constant input
+  signal). An empty (but well-formed) result is now returned instead.
+
 # MassSpecWavelet 1.75.1 (2025-05-03)
 
 - `identifyMajorPeaks()`: 

--- a/R/identifyMajorPeaks.R
+++ b/R/identifyMajorPeaks.R
@@ -158,6 +158,28 @@ identifyMajorPeaks <- function(ms, ridgeList, wCoefs, scales = as.numeric(colnam
         }
     }
 
+    ## No ridges were found (e.g. a flat/constant signal produces no local maxima),
+    ## so return an empty (but well-formed) result instead of crashing below.
+    if (length(ridgeList) == 0) {
+        empty <- structure(numeric(0), names = character(0))
+        return(list(
+            peakIndex = empty,
+            peakValue = empty,
+            peakCenterIndex = empty,
+            peakSNR = empty,
+            peakScale = empty,
+            potentialPeakIndex = empty,
+            allPeakIndex = empty,
+            peakRidgeLengthScale = empty,
+            peakNoise = empty,
+            selInd = list(
+                selInd1 = logical(0),
+                selInd2 = logical(0),
+                selInd3 = logical(0)
+            )
+        ))
+    }
+
     ## Get the peak values
     # mzInd <- as.numeric(names(ridgeList))
     ridgeLen <- sapply(ridgeList, length)

--- a/inst/tests/runit.peakDetectionCWT.R
+++ b/inst/tests/runit.peakDetectionCWT.R
@@ -58,6 +58,18 @@ test02_peakDetection <- function() {
         exclude0scaleAmpThresh = TRUE
     )
     checkEquals(30 + 256, unname(peak2$majorPeakInfo$peakIndex), msg = "Peak not found at index 30+256")
-    
-    
+
+
+}
+
+test03_peakDetection_flatSignal <- function() {
+    # A perfectly constant signal produces no ridges. This used to crash with
+    # "Error in strsplit(ridgeName, "_") : non-character argument".
+    flat_signal <- rep(5, 2001)
+    peakInfo <- peakDetectionCWT(
+        flat_signal,
+        scales = c(1, seq(2, 30, 2), seq(32, 64, 4)),
+        exclude0scaleAmpThresh = TRUE
+    )
+    checkEquals(0, length(peakInfo$majorPeakInfo$peakIndex), msg = "No peaks should be found in a flat signal")
 }


### PR DESCRIPTION
When a CWT produces no ridges (e.g. peakDetectionCWT() on a perfectly
constant signal), ridgeList is empty and names(ridgeList) is NULL,
which made strsplit(ridgeName, "_") fail with "non-character argument".
Return a well-formed, empty result instead.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QSVH82XMPFq38YQWaTAaaN