### PR TITLE
Fix getRidge() ridge name mismatches on high resolution spectra

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,9 @@
 Package: MassSpecWavelet
 Type: Package
 Title: Peak Detection for Mass Spectrometry data using wavelet-based algorithms
-Version: 1.79.0
+Version: 1.79.1
 Encoding: UTF-8
-Date: 2025-05-03
+Date: 2026-07-05
 Authors@R: c(
     person(given = "Pan",
            family = "Du",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# MassSpecWavelet development version
+# MassSpecWavelet 1.79.1 (2026-07-05)
 
 - `identifyMajorPeaks()`: Fix `Error in strsplit(ridgeName, "_") : non-character
   argument` crash when no ridges are found (e.g. for a flat/constant input

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,17 @@
   argument` crash when no ridges are found (e.g. for a flat/constant input
   signal). An empty (but well-formed) result is now returned instead.
 
+- `getRidge()`: Fix ridge name/lookup mismatches on high resolution spectra
+  (m/z indices at or above 1e5). Ridge indices were internally promoted from
+  integer to double partway through the tracing loop, and R's default
+  number-to-string coercion uses scientific notation for large "round"
+  doubles (e.g. `200000` -> `"2e+05"`) but never for integers. The same peak
+  could therefore end up keyed under two different strings, causing the
+  internal ridge lookup to silently miss and ridges to be dropped or
+  duplicated. Ridge names are now always built with a representation-
+  independent formatting helper. Thanks to drobertsicl for reporting the
+  issue and suggesting the fix. Closes #8
+
 # MassSpecWavelet 1.75.1 (2025-05-03)
 
 - `identifyMajorPeaks()`: 

--- a/R/getRidge.R
+++ b/R/getRidge.R
@@ -42,16 +42,27 @@
 #' plotRidgeList(ridgeList)
 #'
 getRidge <- function(localMax, iInit = ncol(localMax), step = -1, iFinal = 1, minWinSize = 5, gapTh = 3, skip = NULL, scaleToWinSize = "doubleodd") {
+    ## Numeric indices are used as list names/keys throughout this function to
+    ## track ridges. R's default numeric-to-character coercion switches to
+    ## scientific notation for large doubles (e.g. 200000 -> "2e+05") but never
+    ## for integers, and indices here get promoted from integer to double
+    ## partway through the tracing loop. Without a single, representation-
+    ## independent formatting function, the same peak index can end up keyed
+    ## under two different strings, causing lookups to silently miss and
+    ## ridges to be dropped or duplicated (see issue #8). Force plain decimal
+    ## notation everywhere a numeric index becomes a name or a lookup key.
+    num2str <- function(x) format(x, scientific = FALSE, trim = TRUE)
+
     scales <- as.numeric(colnames(localMax))
     if (is.null(scales)) scales <- seq_len(ncol(localMax))
-    
+
     maxInd_curr <- which(localMax[, iInit] > 0)
     nMz <- nrow(localMax)
-    
+
     if (is.null(skip)) {
         skip <- iInit + 1
     }
-    
+
     ## Identify all the peak paths from the coarse level to detail levels (high column to low column)
     ## Only consider the shortest path
     if (ncol(localMax) > 1) { ## fixed by Steffen Neumann
@@ -60,9 +71,9 @@ getRidge <- function(localMax, iInit = ncol(localMax), step = -1, iFinal = 1, mi
         colInd <- 1
     }
     ridgeList <- as.list(maxInd_curr)
-    names(ridgeList) <- maxInd_curr
+    names(ridgeList) <- num2str(maxInd_curr)
     peakStatus <- as.list(rep(0, length(maxInd_curr)))
-    names(peakStatus) <- maxInd_curr
+    names(peakStatus) <- num2str(maxInd_curr)
     
     ## orphanRidgeList keep the ridges disconnected at certain scale level
     ## Changed by Pan Du 05/11/06
@@ -109,30 +120,31 @@ getRidge <- function(localMax, iInit = ncol(localMax), step = -1, iFinal = 1, mi
         remove.j <- NULL
         for (k in 1:length(maxInd_curr)) {
             ind.k <- maxInd_curr[k]
+            ind.k.name <- num2str(ind.k)
             start.k <- ifelse(ind.k - winSize.j < 1, 1, ind.k - winSize.j)
             end.k <- ifelse(ind.k + winSize.j > nMz, nMz, ind.k + winSize.j)
             ind.curr <- which(localMax[start.k:end.k, col.j] > 0) + start.k - 1
             # ind.curr <- which(localMax[, col.j] > 0)
             if (length(ind.curr) == 0) {
-                status.k <- peakStatus[[as.character(ind.k)]]
+                status.k <- peakStatus[[ind.k.name]]
                 ## bug  work-around (fixed by Steffen Neumann)
                 if (is.null(status.k)) status.k <- gapTh + 1
                 ##
                 if (status.k > gapTh & scale.j >= 2) {
-                    temp <- ridgeList[[as.character(ind.k)]]
+                    temp <- ridgeList[[ind.k.name]]
                     orphanRidgeList <- c(orphanRidgeList, list(temp[1:(length(temp) - status.k)]))
-                    orphanRidgeName <- c(orphanRidgeName, paste(col.j + status.k + 1, ind.k, sep = "_"))
-                    remove.j <- c(remove.j, as.character(ind.k))
+                    orphanRidgeName <- c(orphanRidgeName, paste(num2str(col.j + status.k + 1), ind.k.name, sep = "_"))
+                    remove.j <- c(remove.j, ind.k.name)
                     next
                 } else {
                     ind.curr <- ind.k
-                    peakStatus[[as.character(ind.k)]] <- status.k + 1
+                    peakStatus[[ind.k.name]] <- status.k + 1
                 }
             } else {
-                peakStatus[[as.character(ind.k)]] <- 0
+                peakStatus[[ind.k.name]] <- 0
                 if (length(ind.curr) >= 2) ind.curr <- ind.curr[which.min(abs(ind.curr - ind.k))]
             }
-            ridgeList[[as.character(ind.k)]] <- c(ridgeList[[as.character(ind.k)]], ind.curr)
+            ridgeList[[ind.k.name]] <- c(ridgeList[[ind.k.name]], ind.curr)
             selPeak.j <- c(selPeak.j, ind.curr)
         }
         ## Remove the disconnected lines from the currrent list
@@ -152,31 +164,31 @@ getRidge <- function(localMax, iInit = ncol(localMax), step = -1, iFinal = 1, mi
                 removeInd.jk <- which.max(selLen)
                 removeInd <- c(removeInd, selInd[-removeInd.jk])
                 orphanRidgeList <- c(orphanRidgeList, ridgeList[removeInd.jk])
-                orphanRidgeName <- c(orphanRidgeName, paste(col.j, selPeak.j[removeInd.jk], sep = "_"))
+                orphanRidgeName <- c(orphanRidgeName, paste(num2str(col.j), num2str(selPeak.j[removeInd.jk]), sep = "_"))
             }
             selPeak.j <- selPeak.j[-removeInd]
             ridgeList <- ridgeList[-removeInd]
             peakStatus <- peakStatus[-removeInd]
         }
-        
+
         ## Update the names of the ridgeList as the new selected peaks
         # if (scale.j >= 2) {
-        if (length(ridgeList) > 0) names(ridgeList) <- selPeak.j
-        if (length(peakStatus) > 0) names(peakStatus) <- selPeak.j
+        if (length(ridgeList) > 0) names(ridgeList) <- num2str(selPeak.j)
+        if (length(peakStatus) > 0) names(peakStatus) <- num2str(selPeak.j)
         # }
-        
+
         ## If the level is larger than 3, expand the peak list by including other unselected peaks at that level
         if (scale.j >= 2) {
             maxInd_next <- which(localMax[, col.j] > 0)
             unSelPeak.j <- maxInd_next[!(maxInd_next %in% selPeak.j)]
             newPeak.j <- as.list(unSelPeak.j)
-            names(newPeak.j) <- unSelPeak.j
+            names(newPeak.j) <- num2str(unSelPeak.j)
             ## Update ridgeList
             ridgeList <- c(ridgeList, newPeak.j)
             maxInd_curr <- c(selPeak.j, unSelPeak.j)
             ## Update peakStatus
             newPeakStatus <- as.list(rep(0, length(newPeak.j)))
-            names(newPeakStatus) <- newPeak.j
+            names(newPeakStatus) <- num2str(unSelPeak.j)
             peakStatus <- c(peakStatus, newPeakStatus)
         } else {
             maxInd_curr <- selPeak.j

--- a/inst/tests/runit.getRidge.R
+++ b/inst/tests/runit.getRidge.R
@@ -1,0 +1,57 @@
+test01_getRidge_largeIndicesDoNotUseScientificNotation <- function() {
+    # Regression test for issue #8: ridge names are built by pasting numeric
+    # m/z indices together (e.g. "1_653"). R's default numeric-to-character
+    # coercion switches to scientific notation for large "round" doubles
+    # (e.g. 200000 -> "2e+05"), and getRidge() internally promotes indices
+    # from integer to double partway through its tracing loop. Without
+    # consistent, representation-independent string keys, the same peak
+    # index could end up looked up under two different strings, silently
+    # breaking the ridge tracing (dropped/duplicated ridges).
+    #
+    # High resolution spectra can easily have m/z indices at or above 1e5,
+    # so we build a spectrum with peaks at "round" indices, which is exactly
+    # what used to trigger scientific notation.
+    n <- 120000
+    ms <- rep(0, n)
+    centers <- c(100000, 110000)
+    for (mu in centers) {
+        idx <- max(1, mu - 30):min(n, mu + 30)
+        ms[idx] <- ms[idx] + 1000 * exp(-0.5 * ((idx - mu) / 8)^2)
+    }
+
+    scales <- c(1, seq(2, 30, 2), seq(32, 64, 4))
+    wCoefs <- cwt(ms, scales = scales, wavelet = "mexh")
+    wCoefs <- cbind(as.vector(ms), wCoefs)
+    colnames(wCoefs) <- c(0, scales)
+    localMax <- getLocalMaximumCWT(wCoefs)
+    colnames(localMax) <- colnames(wCoefs)
+
+    ridgeList <- getRidge(localMax, gapTh = 3, skip = 2)
+
+    ridgeName <- names(ridgeList)
+    checkTrue(length(ridgeList) > 0, msg = "Some ridges should have been found")
+    checkTrue(
+        !any(grepl("e[+-]", ridgeName, ignore.case = TRUE)),
+        msg = "Ridge names must never use scientific notation"
+    )
+    checkTrue(
+        all(grepl("^[0-9]+_[0-9]+$", ridgeName)),
+        msg = "Ridge names must be of the form '<level>_<mzIndex>' using plain digits"
+    )
+
+    # The m/z index encoded in the ridge name must match the first element of
+    # the ridge itself: if a lookup mismatch had split/duplicated a ridge
+    # in getRidge(), this invariant would be the first thing to break.
+    ridgeInfo <- matrix(as.numeric(unlist(strsplit(ridgeName, "_"))), nrow = 2)
+    mzIndFromName <- ridgeInfo[2, ]
+    mzIndFromRidge <- sapply(ridgeList, function(x) x[1])
+    checkEquals(unname(mzIndFromName), unname(mzIndFromRidge), msg = "Ridge name m/z index must match the ridge's own first element")
+
+    # Each synthetic peak should be found by exactly one ridge, reaching the
+    # finest scale (i.e. not truncated/orphaned because of a name mismatch).
+    for (mu in centers) {
+        nearby <- which(abs(mzIndFromRidge - mu) <= 5)
+        checkEquals(1, length(nearby), msg = paste("Expected exactly one ridge near m/z index", mu))
+        checkTrue(length(ridgeList[[nearby]]) >= length(scales) - 3, msg = paste("Ridge near", mu, "looks truncated"))
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes #8: `getRidge()` could silently drop or duplicate ridges for spectra with m/z indices at or above 1e5.
- Root cause: ridge indices are used as list names/keys while tracing ridges, but get internally promoted from integer to double partway through the tracing loop (via arithmetic with a double-typed window size). R's default number-to-string coercion uses scientific notation for large "round" doubles (e.g. `200000` -> `"2e+05"`) but never for integers, so the same peak index could end up keyed under two different strings within a single `getRidge()` call, causing an internal lookup miss that silently drops or duplicates the ridge.
- Fix: force a single, representation-independent formatting helper (`format(x, scientific = FALSE, trim = TRUE)`) everywhere a numeric index becomes a ridge name or lookup key inside `getRidge()`. The downstream consumers (`getRidgeValue()`, `identifyMajorPeaks()`, `tuneInPeakInfo()`, `plotRidgeList()`) only ever parse ridge names back into numbers via `strsplit()` + `as.numeric()`, which round-trips correctly regardless of notation, so no changes were needed there.

## Test plan

- [x] Added `inst/tests/runit.getRidge.R` with a regression test that builds a synthetic high-resolution spectrum (m/z indices at round multiples of 1e5) and asserts ridge names never use scientific notation, always match `^[0-9]+_[0-9]+$`, and that the m/z index encoded in each name matches the ridge's own first element.
- [x] Verified the new test fails against the pre-fix code and passes against the fix.
- [x] Ran the full RUnit suite (`Rscript tests/runit.R`) — 9 test functions, 0 errors, 0 failures.
- [x] Updated `NEWS.md`.

https://claude.ai/code/session_01QSVH82XMPFq38YQWaTAaaN


---
_Generated by [Claude Code](https://claude.ai/code/session_01QSVH82XMPFq38YQWaTAaaN)_