### PR TITLE
Backport tuneInPeakInfo() crash fixes to RELEASE_3_23

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: MassSpecWavelet
 Type: Package
 Title: Peak Detection for Mass Spectrometry data using wavelet-based algorithms
-Version: 1.78.1
+Version: 1.78.2
 Encoding: UTF-8
 Date: 2026-07-05
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,23 @@
+# MassSpecWavelet 1.78.2 (2026-07-05)
+
+- `tuneInPeakInfo()`: Fix three crashes found while adding unit tests for this
+  function:
+   * A peak whose local refinement window contains no ridges (e.g. a
+     quiet/flat neighborhood) crashed with
+     `Error in strsplit(ridgeName.i, "_") : non-character argument` (the same
+     bug class fixed earlier in `identifyMajorPeaks()`). That peak is now
+     left unprocessed instead.
+   * Calling `tuneInPeakInfo()` via the direct `peakIndex`/`peakScale`
+     arguments (instead of `majorPeakInfo`) could crash with
+     `attempt to set an attribute on NULL` if any peak ended up unprocessed.
+     `NA` is now used as a placeholder when there is no original value to
+     fall back on.
+   * `peakDetectionCWT(tuneIn = TRUE)` on a flat/constant signal (whose
+     `majorPeakInfo$peakIndex` is empty) crashed with
+     `missing value where TRUE/FALSE needed`, since `for (i in 1:length(x))`
+     iterates twice when `x` has length 0. Fixed to return a well-formed
+     empty result instead.
+
 # MassSpecWavelet 1.78.1 (2026-07-05)
 
 - `identifyMajorPeaks()`: Fix `Error in strsplit(ridgeName, "_") : non-character

--- a/R/tuneInPeakInfo.R
+++ b/R/tuneInPeakInfo.R
@@ -56,11 +56,11 @@ tuneInPeakInfo <- function(ms, majorPeakInfo = NULL, peakIndex = NULL, peakScale
 
     peakName <- names(peakIndex)
     if (is.null(peakIndex)) peakName <- as.character(peakIndex)
-    peakCenterIndex.new <- NULL
-    peakScale.new <- NULL
-    peakValue.new <- NULL
-    unProcessedInd <- NULL
-    for     (i in 1:length(peakIndex)) {
+    peakCenterIndex.new <- numeric(0)
+    peakScale.new <- numeric(0)
+    peakValue.new <- numeric(0)
+    unProcessedInd <- integer(0)
+    for     (i in seq_along(peakIndex)) {
         peak.i <- peakIndex[i]
         # peak.i <- peakCenterIndex[i]
         peakScale.i <- peakScale[i]
@@ -90,7 +90,7 @@ tuneInPeakInfo <- function(ms, majorPeakInfo = NULL, peakIndex = NULL, peakScale
         }
         if (length(scales.i) <= 1) {
             peakScale.new <- c(peakScale.new, peakScale[i])
-            peakValue.new <- c(peakValue.new, peakValue[i])
+            peakValue.new <- c(peakValue.new, if (is.null(peakValue)) NA_real_ else peakValue[i])
             peakCenterIndex.new <- c(peakCenterIndex.new, peakCenterIndex[i])
             unProcessedInd <- c(unProcessedInd, i)
             next
@@ -108,6 +108,17 @@ tuneInPeakInfo <- function(ms, majorPeakInfo = NULL, peakIndex = NULL, peakScale
         ## -----------------------------------------
         ## Identify the ridges from coarse level to more detailed levels
         ridgeList.i <- getRidge(localMax.i, gapTh = 3, skip = NULL, ...)
+
+        ## No ridges were found in this peak's local refinement window (e.g.
+        ## a quiet/flat neighborhood), so keep the original peak information
+        ## instead of crashing on strsplit(NULL, "_").
+        if (length(ridgeList.i) == 0) {
+            peakScale.new <- c(peakScale.new, peakScale[i])
+            peakValue.new <- c(peakValue.new, if (is.null(peakValue)) NA_real_ else peakValue[i])
+            peakCenterIndex.new <- c(peakCenterIndex.new, peakCenterIndex[i])
+            unProcessedInd <- c(unProcessedInd, i)
+            next
+        }
 
         ridgeName.i <- names(ridgeList.i)
         ridgeInfo.i <- matrix(as.numeric(unlist(strsplit(ridgeName.i, "_"))), nrow = 2)


### PR DESCRIPTION
## Summary

Backports the bugfix commit from #18 (cherry-pick of `84c61ad`) to `RELEASE_3_23` (v1.78.1), the current stable Bioconductor release. The regression test commit from #18 is intentionally **not** included here: it's written against `testthat`, and this release branch still uses the pre-migration RUnit setup (the testthat migration was never backported to a release branch).

Fixes three crashes in `tuneInPeakInfo()` (the `peakDetectionCWT(tuneIn = TRUE)` refinement path):

1. A peak whose local refinement window contains no ridges (e.g. a quiet/flat neighborhood) crashed with `Error in strsplit(ridgeName.i, "_") : non-character argument` — the same bug class fixed earlier in `identifyMajorPeaks()`. That peak is now left unprocessed instead.
2. Calling `tuneInPeakInfo()` via the direct `peakIndex`/`peakScale` arguments (instead of `majorPeakInfo`) could crash with `attempt to set an attribute on NULL` if any peak ended up unprocessed. `NA` is now used as a placeholder when there is no original value to fall back on.
3. `peakDetectionCWT(tuneIn = TRUE)` on a flat/constant signal crashed with `missing value where TRUE/FALSE needed`, since `for (i in 1:length(x))` iterates twice when `x` has length 0. Fixed to return a well-formed empty result instead.

Version bump: `1.78.1` -> `1.78.2`.

## Test plan

- [x] Cherry-pick applied cleanly onto `RELEASE_3_23`, no conflicts.
- [x] Ran this branch's own RUnit suite (`Rscript tests/runit.R`) — 9 test functions, 0 errors, 0 failures.
- [x] Manually re-verified the originally reported crash (`peakDetectionCWT(flat_signal, tuneIn = TRUE)`) now succeeds on this branch.
- [x] `DESCRIPTION` `Version`/`Date` and `NEWS.md` updated for the `1.78.2` release.

https://claude.ai/code/session_01QSVH82XMPFq38YQWaTAaaN


---
_Generated by [Claude Code](https://claude.ai/code/session_01QSVH82XMPFq38YQWaTAaaN)_