### PR TITLE
Add unit tests for getRidgeLength() and mexh()

### DIFF
--- a/tests/testthat/test-getRidgeLength.R
+++ b/tests/testthat/test-getRidgeLength.R
@@ -1,0 +1,20 @@
+test_that("getRidgeLength() trims a ridge at the point it drops below Th * max", {
+    expect_equal(getRidgeLength(list(c(5, 4, 3, 2, 1), c(5, 3, 1))), c(3, 2))
+})
+
+test_that("getRidgeLength() respects a custom Th", {
+    expect_equal(getRidgeLength(list(c(10, 9, 8, 1)), Th = 0.9), 1)
+})
+
+test_that("getRidgeLength() returns the full length when no point drops below the threshold", {
+    expect_equal(getRidgeLength(list(c(5, 5, 5, 5)), Th = 0.5), 4)
+})
+
+test_that("getRidgeLength() returns 1 for a single-element ridge regardless of Th", {
+    expect_equal(getRidgeLength(list(7), Th = 0.99), 1)
+})
+
+test_that("getRidgeLength() preserves the names of a named ridgeList", {
+    result <- getRidgeLength(list(a = c(5, 4, 3, 2, 1), b = c(5, 3, 1)))
+    expect_equal(result, c(a = 3, b = 2))
+})

--- a/tests/testthat/test-mexh.R
+++ b/tests/testthat/test-mexh.R
@@ -1,0 +1,33 @@
+## mexh() is a trivial closed-form function, so the point of testing it isn't
+## hunting for bugs -- it's pinning the exact wavelet formula as a regression
+## guard, since cwt() defaults to wavelet = "mexh" and no existing test
+## checks this formula directly (only end-to-end CWT behavior).
+
+test_that("mexh() matches its documented closed form at known points", {
+    expect_equal(mexh(0), 2 / sqrt(3) * pi^(-0.25))
+    expect_equal(mexh(1), 0) # the (1 - x^2) root
+    expect_equal(mexh(-1), 0)
+    # A generic (non-root, non-origin) reference value, precise to 15 digits,
+    # so a subtly wrong formula (e.g. a wrong exponent denominator) that
+    # happens to agree at x = 0 and x = +-1 still gets caught.
+    expect_equal(mexh(2), -0.352139052257134, tolerance = 1e-14)
+})
+
+test_that("mexh() is an even (symmetric) function", {
+    x <- c(-3, -1.5, -0.5, 0.5, 1.5, 3)
+    expect_equal(mexh(x), mexh(-x))
+})
+
+test_that("mexh() is positive for |x| < 1 and negative for |x| > 1", {
+    expect_true(all(mexh(c(-0.9, -0.5, 0, 0.5, 0.9)) > 0))
+    expect_true(all(mexh(c(-3, -2, -1.1, 1.1, 2, 3)) < 0))
+})
+
+test_that("mexh() decays to (near) zero far from the origin", {
+    expect_lt(abs(mexh(20)), 1e-10)
+})
+
+test_that("mexh() is vectorized and preserves length, including the empty case", {
+    expect_length(mexh(1:10), 10)
+    expect_length(mexh(numeric(0)), 0)
+})


### PR DESCRIPTION
## Summary

Two small, self-contained, previously-untested functions:

- **`getRidgeLength()`**: the doctest example from its own `@examples`, a custom `Th`, the "never truncated" and single-element edge cases, and name preservation for a named `ridgeList`.
- **`mexh()`**: since this is a trivial closed-form function, the point isn't hunting for bugs but pinning the exact wavelet formula as a regression guard (`cwt()` defaults to `wavelet = "mexh"`, and no existing test checks this formula directly). Covers known exact values (including a generic non-root reference point, precise to 15 digits, so a subtly wrong exponent that happens to agree at `x = 0` and `x = +-1` still gets caught), symmetry, sign structure, decay, and vectorization.

No version bump: more test-coverage work is planned before the next Bioconductor push.

## Test plan

- [x] Every expectation was derived from the functions' actual, empirically verified output.
- [x] Manually confirmed both files catch a sabotaged implementation: a wrong `Th` comparison operator (`>=` instead of `>`) in `getRidgeLength()`, and a wrong exponent denominator in `mexh()` (which the first draft of the test *missed* until I added a reference value away from the trivial `x = 0`/`x = ±1` points — noted in the commit).
- [x] Full suite: `cd tests && Rscript testthat.R` -> 624 assertions, 0 failures, 0 warnings, 0 skips.

https://claude.ai/code/session_01QSVH82XMPFq38YQWaTAaaN


---
_Generated by [Claude Code](https://claude.ai/code/session_01QSVH82XMPFq38YQWaTAaaN)_