### PR TITLE
Add unit tests for findLocalMaxWinSize() and fix its export/doc mismatch

### DIFF
--- a/R/findLocalMaxWinSize.R
+++ b/R/findLocalMaxWinSize.R
@@ -8,15 +8,17 @@
 #' @param capWinSize the maximum window size to report. `NA` means unlimited.
 #' @return An integer vector `y` of the same length as `x`. `y[i]` will be the
 #' size of the largest window on `x` containing `x[i]` where:
-#'  - `x[i]` is a local maximum or a center of a plateau
-#'  - `x[i]` is not at a window border
-#'  Optionally, if `capWinSize` is a positive integer, the maximum window size
-#'  is capped to that value, to increase performance. Use this in case you just
-#'  want to check if there exists a window of that size.
-#'  @export
-#'  @examples 
-#'  x <- c(1, 2, 3, 2, 1)
-#'  findLocalMaxWinSize(x)
+#' - `x[i]` is a local maximum or a center of a plateau
+#' - `x[i]` is not at a window border
+#' Optionally, if `capWinSize` is a positive integer, the maximum window size
+#' is capped to that value, to increase performance. Use this in case you just
+#' want to check if there exists a window of that size.
+#' @keywords internal
+#' @examples
+#' \donttest{
+#' x <- c(1, 2, 3, 2, 1)
+#' findLocalMaxWinSize(x)
+#' }
 findLocalMaxWinSize <- function(x, capWinSize = NA) {
     .Call(c_findLocalMaxWinSize, as.double(x), capWinSize = as.integer(capWinSize))
 }

--- a/man/findLocalMaxWinSize.Rd
+++ b/man/findLocalMaxWinSize.Rd
@@ -20,10 +20,6 @@ size of the largest window on \code{x} containing \code{x[i]} where:
 Optionally, if \code{capWinSize} is a positive integer, the maximum window size
 is capped to that value, to increase performance. Use this in case you just
 want to check if there exists a window of that size.
-@export
-@examples
-x <- c(1, 2, 3, 2, 1)
-findLocalMaxWinSize(x)
 }
 }
 \description{
@@ -31,3 +27,10 @@ Compared to the rest of the package, this is a rather experimental function.
 If you plan to use it or are interested in it, please open an issue at
 https://github.com/zeehio/MassSpecWavelet/issues to show your interest.
 }
+\examples{
+\donttest{
+x <- c(1, 2, 3, 2, 1)
+findLocalMaxWinSize(x)
+}
+}
+\keyword{internal}

--- a/tests/testthat/test-findLocalMaxWinSize.R
+++ b/tests/testthat/test-findLocalMaxWinSize.R
@@ -1,0 +1,54 @@
+## findLocalMaxWinSize() has zero test coverage of its C implementation
+## (find_local_maximum.c). Despite its roxygen comment saying `@export`, it is
+## not actually listed in NAMESPACE, so it is only reachable via `:::` today;
+## these tests access it the same way.
+findLocalMaxWinSize <- MassSpecWavelet:::findLocalMaxWinSize
+
+test_that("findLocalMaxWinSize() matches its own documented example", {
+    expect_equal(findLocalMaxWinSize(c(1, 2, 3, 2, 1)), c(0, 0, 5, 0, 0))
+})
+
+test_that("findLocalMaxWinSize() reports 0 everywhere for a monotonic signal", {
+    expect_equal(findLocalMaxWinSize(c(1, 2, 3, 4, 5)), rep(0, 5))
+    expect_equal(findLocalMaxWinSize(c(5, 4, 3, 2, 1)), rep(0, 5))
+})
+
+test_that("findLocalMaxWinSize() reports 0 everywhere for a fully flat signal", {
+    # A signal with no rising/falling edge anywhere has no discernible peak,
+    # even though every point is technically tied for the maximum.
+    expect_equal(findLocalMaxWinSize(c(3, 3, 3, 3, 3)), rep(0, 5))
+    expect_equal(findLocalMaxWinSize(c(3, 3, 3, 3)), rep(0, 4))
+})
+
+test_that("an equal-height neighboring peak does not block window growth", {
+    # Two isolated peaks of the same height: neither is strictly greater than
+    # the other, so each gets a window spanning the whole signal.
+    expect_equal(findLocalMaxWinSize(c(0, 1, 0, 0, 0, 1, 0)), c(0, 7, 0, 0, 0, 7, 0))
+    expect_equal(findLocalMaxWinSize(c(0, 1, 0, 1, 0)), c(0, 5, 0, 5, 0))
+})
+
+test_that("capWinSize caps the reported window size, and NA means unlimited", {
+    x <- c(1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1) # single peak at position 6
+    expect_equal(findLocalMaxWinSize(x, capWinSize = 3L)[6], 3L)
+    expect_equal(findLocalMaxWinSize(x, capWinSize = 1L)[6], 1L)
+    expect_equal(findLocalMaxWinSize(x, capWinSize = 0L)[6], 0L)
+    expect_equal(findLocalMaxWinSize(x, capWinSize = NA)[6], 11L) # unlimited: the whole signal
+})
+
+test_that("findLocalMaxWinSize() reports the exact center of an odd-length plateau", {
+    x <- c(0, 1, 2, 3, 3, 3, 2, 1, 0) # plateau of 3 points at positions 4:6
+    result <- findLocalMaxWinSize(x)
+    expect_equal(which(result > 0), 5) # the middle of the plateau
+})
+
+test_that("findLocalMaxWinSize() reports the first of the two centers of an even-length plateau", {
+    x <- c(0, 1, 2, 3, 3, 2, 1, 0) # plateau of 2 points at positions 4:5
+    result <- findLocalMaxWinSize(x)
+    expect_equal(which(result > 0), 4) # the first of the two candidate centers
+})
+
+test_that("findLocalMaxWinSize() handles length 0, 1 and 2 inputs without crashing", {
+    expect_equal(findLocalMaxWinSize(numeric(0)), integer(0))
+    expect_equal(findLocalMaxWinSize(5), 0L)
+    expect_equal(findLocalMaxWinSize(c(1, 2)), c(0L, 0L))
+})


### PR DESCRIPTION
## Summary

### Commit 1: unit tests

The last remaining function with zero test coverage: a C-implemented (`find_local_maximum.c`), explicitly experimental algorithm used by `localMaximum()`'s opt-in `"new"` algorithm path (`options(MassSpecWavelet.localMaximum.algorithm = "new")`). Until now, only its indirect effect (via `localMaximum()`'s own `>= winSize` thresholding) was exercised by `test-localMaximum.R`; this tests the function's actual raw window-size output directly.

Covers:
- The function's own documented example.
- Monotonic and fully flat signals (both report all zeros — a flat signal has no discernible peak even though every point ties for the max).
- An equal-height neighboring peak not blocking window growth (only a strictly greater point does).
- `capWinSize` capping, including `0` and `NA` (unlimited).
- The odd- and even-length plateau center tie-break rules described in the "Finding local maxima" vignette (odd -> exact center; even -> first of the two candidate centers).
- The length 0/1/2 edge cases.

### Commit 2: fix the `@export`/`NAMESPACE` mismatch found while writing the tests

`@return`'s continuation lines used two-space indentation (`#'  ...`) instead of one, which made roxygen2 treat the following `@export` and `@examples` lines as more `@return` prose instead of parsing them as tags — they were literally dumped as text at the end of the generated `\value{}` section, and the function was never actually exported despite the source claiming `@export` (confirmed with `roxygen2::parse_file()`: only a `"return"` tag existed, no `"export"` or `"examples"` tag was ever produced).

Now that `@keywords`/`@examples` parse correctly, marked this function `@keywords internal` instead of (recognized-for-the-first-time) `@export`: it's explicitly documented as experimental and was completely untested until the first commit here, so it shouldn't become part of the public API by accident. This matches the existing convention for the package's other internal-but-documented helpers (`extendLength()`, `extendNBase()`). `NAMESPACE` is unaffected — the function was never in it to begin with.

Also wrapped the example in `\donttest{}`, matching `extendLength()`'s precedent: now that `@examples` is a real tag, its bare (non-exported) function call needs to be donttest-skipped, or `R CMD check`'s example step would try to run it under a plain `library(MassSpecWavelet)` and fail with "could not find function".

No version bump: more test-coverage work is planned before the next Bioconductor push.

## Test plan

- [x] Every test expectation was derived from the function's actual, empirically verified output (not guessed) — including tracing the C implementation to explain *why* a fully flat signal reports no peak.
- [x] Manually confirmed the "ties don't block growth" test fails when the C comparison is sabotaged from `>` to `>=`: rebuilt with the sabotage (2 failures, exactly on that test), then reverted the C source and confirmed it's byte-identical to the committed version (`git diff` empty) before rebuilding again.
- [x] Confirmed the roxygen fix with `roxygen2::parse_file()` directly: `@keywords`/`@examples` are now real, separate tags (previously swallowed into `@return`'s text).
- [x] Regenerated `NAMESPACE`/`man/` with `roxygen2::roxygenise()` and confirmed `NAMESPACE` is byte-identical (function still not exported, as intended).
- [x] Ran a real `R CMD check` and confirmed the `\donttest{}`-wrapped example is correctly skipped (verified by inspecting the generated `MassSpecWavelet-Ex.R`), and that the only check failure is the pre-existing, unrelated `signal` package gap in this sandbox.
- [x] Full suite: `cd tests && Rscript testthat.R` -> 640 assertions, 0 failures, 0 warnings, 0 skips.

https://claude.ai/code/session_01QSVH82XMPFq38YQWaTAaaN
