### PR TITLE
Deprecate six unused functions ahead of removal

### DIFF
--- a/R/getRidgeValue.R
+++ b/R/getRidgeValue.R
@@ -2,6 +2,10 @@
 #'
 #' Get the CWT coefficient values corresponding to the peak ridge
 #'
+#' **Deprecated**: this function appears to be unused, both internally in
+#' MassSpecWavelet and by known downstream packages, and is scheduled for
+#' removal in a future release. If you rely on it, please open an issue at
+#' <https://github.com/zeehio/MassSpecWavelet/issues> within the next year.
 #'
 #' @param ridgeList a list of ridge lines
 #' @param wCoefs 2-D CWT coefficients
@@ -11,6 +15,12 @@
 #' @author Pan Du
 #' @keywords methods
 getRidgeValue <- function(ridgeList, wCoefs, skip = 0) {
+    .Deprecated(msg = paste(
+        "getRidgeValue() appears to be unused, both internally in MassSpecWavelet",
+        "and by known downstream packages, and is scheduled for removal in a",
+        "future release. If you rely on it, please open an issue at",
+        "https://github.com/zeehio/MassSpecWavelet/issues within the next year."
+    ))
     ridgeLen <- sapply(ridgeList, length)
     ridgeName <- names(ridgeList)
     ridgeInfo <- matrix(as.numeric(unlist(strsplit(ridgeName, "_"))), nrow = 2)

--- a/R/i2u.R
+++ b/R/i2u.R
@@ -1,4 +1,10 @@
 i2u <- function(i, t0 = 9.0E-8, a = 3.36301655051424E8, b = 0, U = 20000, delta = 4.0E-9) {
+    .Deprecated(msg = paste(
+        "i2u() appears to be unused, both internally in MassSpecWavelet and by",
+        "known downstream packages, and is scheduled for removal in a future",
+        "release. If you rely on it, please open an issue at",
+        "https://github.com/zeehio/MassSpecWavelet/issues within the next year."
+    ))
     t <- i * delta # in seconds
     u <- (a * (t - t0)^2 + b) * U # here is m/z at 150KDa
     return(u)

--- a/R/mzInd2vRange.R
+++ b/R/mzInd2vRange.R
@@ -2,6 +2,10 @@
 #'
 #' Match m/z index to m/z value with a certain error range
 #'
+#' **Deprecated**: this function appears to be unused, both internally in
+#' MassSpecWavelet and by known downstream packages, and is scheduled for
+#' removal in a future release. If you rely on it, please open an issue at
+#' <https://github.com/zeehio/MassSpecWavelet/issues> within the next year.
 #'
 #' @param mzInd a vector of m/z index
 #' @param error error range
@@ -10,10 +14,18 @@
 #' @seealso [mzV2indRange()]
 #' @keywords methods
 mzInd2vRange <- function(mzInd, error = 0.003) {
+    .Deprecated(msg = paste(
+        "mzInd2vRange() appears to be unused, both internally in MassSpecWavelet",
+        "and by known downstream packages, and is scheduled for removal in a",
+        "future release. If you rely on it, please open an issue at",
+        "https://github.com/zeehio/MassSpecWavelet/issues within the next year."
+    ))
     mzVR <- NULL
     for (i in 1:length(mzInd)) {
-        from.i <- round(i2u(mzInd[i]) * (1 - error))
-        to.i <- round(i2u(mzInd[i]) * (1 + error))
+        # suppressWarnings(): avoid repeating i2u()'s own deprecation warning
+        # once per loop iteration; the warning above already covers this call.
+        from.i <- round(suppressWarnings(i2u(mzInd[i])) * (1 - error))
+        to.i <- round(suppressWarnings(i2u(mzInd[i])) * (1 + error))
         mzVR <- c(mzVR, from.i:to.i)
     }
     mzVR <- sort(unique(mzVR))

--- a/R/mzV2indRange.R
+++ b/R/mzV2indRange.R
@@ -2,6 +2,10 @@
 #'
 #' Match m/z value to m/z index with a certain error range
 #'
+#' **Deprecated**: this function appears to be unused, both internally in
+#' MassSpecWavelet and by known downstream packages, and is scheduled for
+#' removal in a future release. If you rely on it, please open an issue at
+#' <https://github.com/zeehio/MassSpecWavelet/issues> within the next year.
 #'
 #' @param mzV a vector of m/z value
 #' @param error error range
@@ -10,10 +14,18 @@
 #' @seealso [mzInd2vRange()]
 #' @keywords methods
 mzV2indRange <- function(mzV, error = 0.003) {
+    .Deprecated(msg = paste(
+        "mzV2indRange() appears to be unused, both internally in MassSpecWavelet",
+        "and by known downstream packages, and is scheduled for removal in a",
+        "future release. If you rely on it, please open an issue at",
+        "https://github.com/zeehio/MassSpecWavelet/issues within the next year."
+    ))
     mzIndR <- NULL
     for (i in 1:length(mzV)) {
-        from.i <- round(u2i(mzV[i] * (1 - error)))
-        to.i <- round(u2i(mzV[i] * (1 + error)))
+        # suppressWarnings(): avoid repeating u2i()'s own deprecation warning
+        # once per loop iteration; the warning above already covers this call.
+        from.i <- round(suppressWarnings(u2i(mzV[i] * (1 - error))))
+        to.i <- round(suppressWarnings(u2i(mzV[i] * (1 + error))))
         mzIndR <- c(mzIndR, from.i:to.i)
     }
     mzIndR <- sort(unique(mzIndR))

--- a/R/smoothDWT.R
+++ b/R/smoothDWT.R
@@ -2,6 +2,10 @@
 #'
 #' Smooth (denoise) the spectrum by DWT (Discrete Wavelet Transform)
 #'
+#' **Deprecated**: this function appears to be unused, both internally in
+#' MassSpecWavelet and by known downstream packages, and is scheduled for
+#' removal in a future release. If you rely on it, please open an issue at
+#' <https://github.com/zeehio/MassSpecWavelet/issues> within the next year.
 #'
 #' @param ms a vector representing the mass spectrum
 #' @param nLevel the level of DWT decomposition
@@ -19,6 +23,12 @@
 #' @keywords methods
 smoothDWT <- function(ms, nLevel = 6, wf = "la8", localNoiseTh = seq(1, 0, by = -0.2), localWinSize = 500, globalNoiseTh = 0.75,
     smoothMethod = c("soft", "hard"), method = c("dwt", "modwt")) {
+    .Deprecated(msg = paste(
+        "smoothDWT() appears to be unused, both internally in MassSpecWavelet",
+        "and by known downstream packages, and is scheduled for removal in a",
+        "future release. If you rely on it, please open an issue at",
+        "https://github.com/zeehio/MassSpecWavelet/issues within the next year."
+    ))
     if (!requireNamespace("waveslim", quietly = TRUE)) {
         stop("Please install the waveslim package to use smoothDWT()")
     }

--- a/R/u2i.R
+++ b/R/u2i.R
@@ -1,4 +1,10 @@
 u2i <- function(u, t0 = 9.0E-8, a = 3.36301655051424E8, b = 0, U = 20000, delta = 4.0E-9) {
+    .Deprecated(msg = paste(
+        "u2i() appears to be unused, both internally in MassSpecWavelet and by",
+        "known downstream packages, and is scheduled for removal in a future",
+        "release. If you rely on it, please open an issue at",
+        "https://github.com/zeehio/MassSpecWavelet/issues within the next year."
+    ))
     i <- (((u / U - b) / a)^(1 / 2) + t0) / delta
     return(floor(i)) # just take the integer part
 }

--- a/man/getRidgeValue.Rd
+++ b/man/getRidgeValue.Rd
@@ -20,6 +20,12 @@ A list of ridge values corresponding to the input ridgeList.
 \description{
 Get the CWT coefficient values corresponding to the peak ridge
 }
+\details{
+\strong{Deprecated}: this function appears to be unused, both internally in
+MassSpecWavelet and by known downstream packages, and is scheduled for
+removal in a future release. If you rely on it, please open an issue at
+\url{https://github.com/zeehio/MassSpecWavelet/issues} within the next year.
+}
 \author{
 Pan Du
 }

--- a/man/mzInd2vRange.Rd
+++ b/man/mzInd2vRange.Rd
@@ -17,6 +17,12 @@ return a vector of sorted m/z values
 \description{
 Match m/z index to m/z value with a certain error range
 }
+\details{
+\strong{Deprecated}: this function appears to be unused, both internally in
+MassSpecWavelet and by known downstream packages, and is scheduled for
+removal in a future release. If you rely on it, please open an issue at
+\url{https://github.com/zeehio/MassSpecWavelet/issues} within the next year.
+}
 \seealso{
 \code{\link[=mzV2indRange]{mzV2indRange()}}
 }

--- a/man/mzV2indRange.Rd
+++ b/man/mzV2indRange.Rd
@@ -17,6 +17,12 @@ return a vector of sorted m/z indexes
 \description{
 Match m/z value to m/z index with a certain error range
 }
+\details{
+\strong{Deprecated}: this function appears to be unused, both internally in
+MassSpecWavelet and by known downstream packages, and is scheduled for
+removal in a future release. If you rely on it, please open an issue at
+\url{https://github.com/zeehio/MassSpecWavelet/issues} within the next year.
+}
 \seealso{
 \code{\link[=mzInd2vRange]{mzInd2vRange()}}
 }

--- a/man/smoothDWT.Rd
+++ b/man/smoothDWT.Rd
@@ -41,6 +41,12 @@ as an attribute 'detail'.
 \description{
 Smooth (denoise) the spectrum by DWT (Discrete Wavelet Transform)
 }
+\details{
+\strong{Deprecated}: this function appears to be unused, both internally in
+MassSpecWavelet and by known downstream packages, and is scheduled for
+removal in a future release. If you rely on it, please open an issue at
+\url{https://github.com/zeehio/MassSpecWavelet/issues} within the next year.
+}
 \author{
 Pan Du
 }

--- a/tests/testthat/test-deprecated.R
+++ b/tests/testthat/test-deprecated.R
@@ -1,22 +1,24 @@
 ## getRidgeValue(), i2u(), u2i(), mzInd2vRange(), mzV2indRange() and
 ## smoothDWT() are unused, both internally in MassSpecWavelet and by known
 ## downstream packages (checked against xcms). They are marked deprecated
-## via .Deprecated() as a heads-up before removal; none of them are exported,
-## so they are only reachable via `:::`.
+## via .Deprecated() as a heads-up before removal. None of them are exported,
+## but testthat's test environment is a clone of the package namespace (see
+## testthat:::test_env()), so unexported functions resolve here by their bare
+## name, same as exported ones.
 
 test_that("getRidgeValue() warns that it is deprecated", {
     ridgeList <- list("1_2" = c(2L, 2L, 2L))
     attr(ridgeList, "scales") <- 0:2
     wCoefs <- matrix(1:15, nrow = 5, ncol = 3)
     expect_warning(
-        MassSpecWavelet:::getRidgeValue(ridgeList, wCoefs),
+        getRidgeValue(ridgeList, wCoefs),
         class = "deprecatedWarning"
     )
 })
 
 test_that("i2u() and u2i() warn that they are deprecated", {
-    expect_warning(MassSpecWavelet:::i2u(100), class = "deprecatedWarning")
-    expect_warning(MassSpecWavelet:::u2i(500000), class = "deprecatedWarning")
+    expect_warning(i2u(100), class = "deprecatedWarning")
+    expect_warning(u2i(500000), class = "deprecatedWarning")
 })
 
 count_deprecated_warnings <- function(expr) {
@@ -35,14 +37,14 @@ test_that("mzInd2vRange() and mzV2indRange() warn exactly once, even for multi-e
     # These call i2u()/u2i() internally in a loop (once per element); a naive
     # implementation would emit one deprecation warning per loop iteration
     # instead of once for the outer call.
-    expect_equal(count_deprecated_warnings(MassSpecWavelet:::mzInd2vRange(1:10)), 1)
-    expect_equal(count_deprecated_warnings(MassSpecWavelet:::mzV2indRange((1:10) * 100000)), 1)
+    expect_equal(count_deprecated_warnings(mzInd2vRange(1:10)), 1)
+    expect_equal(count_deprecated_warnings(mzV2indRange((1:10) * 100000)), 1)
 })
 
 test_that("smoothDWT() warns that it is deprecated even when it later errors", {
     skip_if(requireNamespace("waveslim", quietly = TRUE), "waveslim is installed, smoothDWT() would not error")
     expect_warning(
-        expect_error(MassSpecWavelet:::smoothDWT(rnorm(100)), "waveslim"),
+        expect_error(smoothDWT(rnorm(100)), "waveslim"),
         class = "deprecatedWarning"
     )
 })

--- a/tests/testthat/test-deprecated.R
+++ b/tests/testthat/test-deprecated.R
@@ -1,0 +1,48 @@
+## getRidgeValue(), i2u(), u2i(), mzInd2vRange(), mzV2indRange() and
+## smoothDWT() are unused, both internally in MassSpecWavelet and by known
+## downstream packages (checked against xcms). They are marked deprecated
+## via .Deprecated() as a heads-up before removal; none of them are exported,
+## so they are only reachable via `:::`.
+
+test_that("getRidgeValue() warns that it is deprecated", {
+    ridgeList <- list("1_2" = c(2L, 2L, 2L))
+    attr(ridgeList, "scales") <- 0:2
+    wCoefs <- matrix(1:15, nrow = 5, ncol = 3)
+    expect_warning(
+        MassSpecWavelet:::getRidgeValue(ridgeList, wCoefs),
+        class = "deprecatedWarning"
+    )
+})
+
+test_that("i2u() and u2i() warn that they are deprecated", {
+    expect_warning(MassSpecWavelet:::i2u(100), class = "deprecatedWarning")
+    expect_warning(MassSpecWavelet:::u2i(500000), class = "deprecatedWarning")
+})
+
+count_deprecated_warnings <- function(expr) {
+    n <- 0
+    withCallingHandlers(
+        expr,
+        deprecatedWarning = function(w) {
+            n <<- n + 1
+            invokeRestart("muffleWarning")
+        }
+    )
+    n
+}
+
+test_that("mzInd2vRange() and mzV2indRange() warn exactly once, even for multi-element input", {
+    # These call i2u()/u2i() internally in a loop (once per element); a naive
+    # implementation would emit one deprecation warning per loop iteration
+    # instead of once for the outer call.
+    expect_equal(count_deprecated_warnings(MassSpecWavelet:::mzInd2vRange(1:10)), 1)
+    expect_equal(count_deprecated_warnings(MassSpecWavelet:::mzV2indRange((1:10) * 100000)), 1)
+})
+
+test_that("smoothDWT() warns that it is deprecated even when it later errors", {
+    skip_if(requireNamespace("waveslim", quietly = TRUE), "waveslim is installed, smoothDWT() would not error")
+    expect_warning(
+        expect_error(MassSpecWavelet:::smoothDWT(rnorm(100)), "waveslim"),
+        class = "deprecatedWarning"
+    )
+})


### PR DESCRIPTION
## Summary

Marks `getRidgeValue()`, `i2u()`, `u2i()`, `mzInd2vRange()`, `mzV2indRange()`, and `smoothDWT()` as deprecated, as a heads-up before removing them a year from now if nobody objects.

**Verification, not assumption**: confirmed none of these six functions are called anywhere internally in MassSpecWavelet (checked the whole repo, and the full git history back to its 2022-10-10 root commit — never wired in, not vestigial). Also cloned and searched `sneumann/xcms` in full — the one known downstream package depending on `MassSpecWavelet`'s peak-detection internals (it calls `peakDetectionCWT`, `tuneInPeakInfo`, `cwt`, `getRidge`, `getLocalMaximumCWT`, `identifyMajorPeaks`, `localMaximum` extensively) — and it never touches any of these six either, nor does it use `MassSpecWavelet:::` at all.

None of the six are exported, so this only affects code reaching them via `:::`.

Each function now calls `.Deprecated()` with a message explaining the situation and inviting anyone relying on it to open a GitHub issue within the next year before removal. The four that already had a man page (`getRidgeValue`, `mzInd2vRange`, `mzV2indRange`, `smoothDWT`) got a matching deprecation note in their docs; `NAMESPACE` is unaffected since none of these were ever exported.

One implementation detail worth calling out: `mzInd2vRange()`/`mzV2indRange()` call `i2u()`/`u2i()` internally in a loop (once per input element). A naive implementation would therefore emit one deprecation warning per element *in addition to* the outer function's own warning — so those internal calls are wrapped in `suppressWarnings()`.

No version bump: more work may still land before the next Bioconductor push.

## Test plan

- [x] Manually verified each of the 6 functions emits exactly one `deprecatedWarning`-class warning per call, including `smoothDWT()` (which warns before it hits its pre-existing `stop()` for the missing `waveslim` package).
- [x] Manually confirmed the loop-warning-spam concern is real and the fix works: sabotaging the `suppressWarnings()` wrapper turned 1 warning into 21 for a 10-element `mzInd2vRange()` call; reverted and confirmed back to 1.
- [x] Added `tests/testthat/test-deprecated.R` covering all of the above as permanent regression tests.
- [x] Regenerated `man/` with `roxygen2::roxygenise()` and confirmed `NAMESPACE` is unaffected.
- [x] Full suite: `cd tests && Rscript testthat.R` -> 647 assertions, 0 failures, 0 warnings, 0 skips.

https://claude.ai/code/session_01QSVH82XMPFq38YQWaTAaaN


---
_Generated by [Claude Code](https://claude.ai/code/session_01QSVH82XMPFq38YQWaTAaaN)_