### PR TITLE
Drop redundant ::: qualifiers in test files

### DIFF
--- a/tests/testthat/test-cwt.R
+++ b/tests/testthat/test-cwt.R
@@ -26,9 +26,6 @@ test_that("cwt_classic, cwt, and prepared-wavelets cwt give identical results", 
     )
 
     scales <- c(1, 2, 4, 8)
-    # cwt_classic() is unexported, but testthat's test environment is a clone
-    # of the package namespace (see testthat:::test_env()), so it resolves
-    # here by its bare name, same as exported functions.
     wCoefs_classic <- cwt_classic(skinny_peak, scales = scales, wavelet = "mexh")
     wCoefs_new <- cwt(skinny_peak, scales = scales, wavelet = "mexh")
     prep_wav <- prepareWavelets(

--- a/tests/testthat/test-cwt.R
+++ b/tests/testthat/test-cwt.R
@@ -26,7 +26,10 @@ test_that("cwt_classic, cwt, and prepared-wavelets cwt give identical results", 
     )
 
     scales <- c(1, 2, 4, 8)
-    wCoefs_classic <- MassSpecWavelet:::cwt_classic(skinny_peak, scales = scales, wavelet = "mexh")
+    # cwt_classic() is unexported, but testthat's test environment is a clone
+    # of the package namespace (see testthat:::test_env()), so it resolves
+    # here by its bare name, same as exported functions.
+    wCoefs_classic <- cwt_classic(skinny_peak, scales = scales, wavelet = "mexh")
     wCoefs_new <- cwt(skinny_peak, scales = scales, wavelet = "mexh")
     prep_wav <- prepareWavelets(
         length(skinny_peak),

--- a/tests/testthat/test-extendLength.R
+++ b/tests/testthat/test-extendLength.R
@@ -5,8 +5,10 @@
 ## default combination (method = "reflection", direction = "right") is ever
 ## exercised indirectly through cwt(); the other 8 method/direction
 ## combinations had no coverage at all.
-extendLength <- MassSpecWavelet:::extendLength
-extendNBase <- MassSpecWavelet:::extendNBase
+##
+## Both functions are unexported, but testthat's test environment is a clone
+## of the package namespace (see testthat:::test_env()), so they resolve here
+## by their bare name, same as exported functions.
 
 test_that("extendLength() pads to the right with each method", {
     x <- 1:5

--- a/tests/testthat/test-extendLength.R
+++ b/tests/testthat/test-extendLength.R
@@ -5,10 +5,6 @@
 ## default combination (method = "reflection", direction = "right") is ever
 ## exercised indirectly through cwt(); the other 8 method/direction
 ## combinations had no coverage at all.
-##
-## Both functions are unexported, but testthat's test environment is a clone
-## of the package namespace (see testthat:::test_env()), so they resolve here
-## by their bare name, same as exported functions.
 
 test_that("extendLength() pads to the right with each method", {
     x <- 1:5

--- a/tests/testthat/test-findLocalMaxWinSize.R
+++ b/tests/testthat/test-findLocalMaxWinSize.R
@@ -1,6 +1,5 @@
 ## findLocalMaxWinSize() has zero test coverage of its C implementation
-## (find_local_maximum.c). Despite its roxygen comment saying `@export`, it is
-## not actually listed in NAMESPACE (see R/findLocalMaxWinSize.R).
+## (find_local_maximum.c).
 
 test_that("findLocalMaxWinSize() matches its own documented example", {
     expect_equal(findLocalMaxWinSize(c(1, 2, 3, 2, 1)), c(0, 0, 5, 0, 0))

--- a/tests/testthat/test-findLocalMaxWinSize.R
+++ b/tests/testthat/test-findLocalMaxWinSize.R
@@ -1,10 +1,6 @@
 ## findLocalMaxWinSize() has zero test coverage of its C implementation
 ## (find_local_maximum.c). Despite its roxygen comment saying `@export`, it is
 ## not actually listed in NAMESPACE (see R/findLocalMaxWinSize.R).
-##
-## It's unexported, but testthat's test environment is a clone of the package
-## namespace (see testthat:::test_env()), so it resolves here by its bare
-## name, same as exported functions.
 
 test_that("findLocalMaxWinSize() matches its own documented example", {
     expect_equal(findLocalMaxWinSize(c(1, 2, 3, 2, 1)), c(0, 0, 5, 0, 0))

--- a/tests/testthat/test-findLocalMaxWinSize.R
+++ b/tests/testthat/test-findLocalMaxWinSize.R
@@ -1,8 +1,10 @@
 ## findLocalMaxWinSize() has zero test coverage of its C implementation
 ## (find_local_maximum.c). Despite its roxygen comment saying `@export`, it is
-## not actually listed in NAMESPACE, so it is only reachable via `:::` today;
-## these tests access it the same way.
-findLocalMaxWinSize <- MassSpecWavelet:::findLocalMaxWinSize
+## not actually listed in NAMESPACE (see R/findLocalMaxWinSize.R).
+##
+## It's unexported, but testthat's test environment is a clone of the package
+## namespace (see testthat:::test_env()), so it resolves here by its bare
+## name, same as exported functions.
 
 test_that("findLocalMaxWinSize() matches its own documented example", {
     expect_equal(findLocalMaxWinSize(c(1, 2, 3, 2, 1)), c(0, 0, 5, 0, 0))


### PR DESCRIPTION
## Summary

Small cleanup: `MassSpecWavelet:::` qualifiers in test files were unnecessary and, in one case, based on a wrong assumption I stated in a comment.

`testthat::test_check()` (what `Rscript tests/testthat.R` and `R CMD check` actually run) builds its test environment via `test_env()` -> `env_clone(asNamespace(package))` — a clone of the **full package namespace**, exported and unexported objects alike. Test code resolves bare names against that clone through normal lexical scoping, so unexported functions never need `:::` in test files.

Removed the now-redundant `MassSpecWavelet:::` from:
- `test-extendLength.R` (`extendLength`, `extendNBase`)
- `test-findLocalMaxWinSize.R` (`findLocalMaxWinSize`)
- `test-cwt.R` (`cwt_classic`)

`test-findLocalMaxWinSize.R` had a comment claiming `:::` was "how it is actually reachable today" — that was wrong, and is corrected here.

No version bump: more work may still land before the next Bioconductor push.

## Test plan

- [x] Verified the claim directly before making this change: temporarily stripped the `:::` alias entirely from `test-findLocalMaxWinSize.R` and ran the real suite via `cd tests && Rscript testthat.R` — all assertions passed with every bare call resolving correctly.
- [x] Full suite after the actual cleanup: `cd tests && Rscript testthat.R` -> 640 assertions, 0 failures, 0 warnings, 0 skips (same count as before, since no test logic changed — only the qualifiers).

https://claude.ai/code/session_01QSVH82XMPFq38YQWaTAaaN


---
_Generated by [Claude Code](https://claude.ai/code/session_01QSVH82XMPFq38YQWaTAaaN)_